### PR TITLE
Added queue, walltime and storage directives to the interpolation context

### DIFF
--- a/hpcpy/client.py
+++ b/hpcpy/client.py
@@ -331,16 +331,20 @@ class PBSClient(Client):
         # Add queue
         if queue:
             directives.append(f"-q {queue}")
+            context["queue"] = queue
 
         # Add walltime
         if walltime:
             _walltime = str(walltime)
             directives.append(f"-l walltime={_walltime}")
+            context["walltime"] = _walltime
 
         # Add storage
         if storage:
             storage_str = "+".join(storage)
             directives.append(f"-l storage={storage_str}")
+            context["storage"] = storage
+            context["storage_str"] = storage_str
 
         # Call the super
         return super().submit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ license = {file="LICENSE"}
 dynamic = ["version"]
 
 # Dependencies
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 dependencies = [
     "Jinja2>=3.1.4",
     "pandas>=2.2.2"


### PR DESCRIPTION
Added the keyword arguments of queue, wall time and storage to the interpolation context. This issue was discovered when integrating meorg_client and benchcab.

Additional notes inline.

#16 is still a priority, but this will fix the current issue.