### PR TITLE
Added client variable passing to PBS command. Fixes #25

### DIFF
--- a/hpcpy/client/pbs.py
+++ b/hpcpy/client/pbs.py
@@ -81,7 +81,7 @@ class PBSClient(BaseClient):
         storage: list, optional
             List of storage mounts to apply, by default None
         variables: dict, optional
-            Key/value pairs added to the qsub command.
+            Key/value environment variable pairs added to the qsub command.
         **context:
             Additional key/value pairs to be added to command/jobscript interpolation
         """

--- a/hpcpy/utilities.py
+++ b/hpcpy/utilities.py
@@ -9,7 +9,7 @@ import shlex
 
 
 def shell(
-    cmd, shell=True, check=True, capture_output=True, **kwargs
+    cmd, check=True, capture_output=True, **kwargs
 ) -> sp.CompletedProcess:
     """Execute a shell command.
 
@@ -17,8 +17,6 @@ def shell(
     ----------
     cmd : str
         Command
-    shell : bool, optional
-        Execute as shell, by default True
     check : bool, optional
         Check output, by default True
     capture_output : bool, optional

--- a/hpcpy/utilities.py
+++ b/hpcpy/utilities.py
@@ -5,6 +5,7 @@ import jinja2 as j2
 import jinja2.meta as j2m
 from pathlib import Path
 from importlib import resources
+import shlex
 
 
 def shell(
@@ -33,7 +34,7 @@ def shell(
     subprocess.CalledProcessError
     """
     return sp.run(
-        cmd, shell=shell, check=check, capture_output=capture_output, **kwargs
+        shlex.split(cmd), check=check, capture_output=capture_output, **kwargs
     )
 
 

--- a/tests/test_pbs_client.py
+++ b/tests/test_pbs_client.py
@@ -62,3 +62,25 @@ def test_storage(client):
     )
 
     assert result == expected
+
+def test_variables(client):
+    """Test passing variables to the qsub command."""
+    expected = "qsub -v var1=1234,var2=abcd test.sh"
+    result = client.submit(
+        "test.sh", dry_run=True, variables=dict(var1=1234, var2="abcd")
+    )
+
+    assert result == expected
+
+def test_variables_empty(client):
+    """Test passing empty variables dict to the qsub command works as expected."""
+    expected = "qsub test.sh"
+    result1 = client.submit(
+        "test.sh", dry_run=True, variables=dict()
+    )
+    result2 = client.submit(
+        "test.sh", dry_run=True
+    )
+
+    assert result1 == expected
+    assert result2 == expected


### PR DESCRIPTION
Added variable interpolation into the directives context.

This supports basic variable passing in the same manner as payu.

If we need to support qsub comma escaping (which payu doesn't seem to? see `man qsub`), then I will take another crack at it.
