### PR TITLE
Added new exception class to reveal more information to the user. Fix…

### DIFF
--- a/hpcpy/client/base.py
+++ b/hpcpy/client/base.py
@@ -172,7 +172,7 @@ class BaseClient:
             Automatically decode response with utf-8, defaults to True
         Raises
         ------
-        hpcypy.excetions.ShellException :
+        hpcpy.exceptions.ShellException :
             When the underlying shell call fails.
 
         Returns

--- a/hpcpy/client/base.py
+++ b/hpcpy/client/base.py
@@ -115,7 +115,6 @@ class BaseClient:
         job_id : str
             Job ID.
         """
-        # raise NotImplementedError()
         cmd = self._tmp_status.format(job_id=job_id)
         result = self._shell(cmd)
         return result
@@ -171,11 +170,15 @@ class BaseClient:
             Command to run.
         decode : bool
             Automatically decode response with utf-8, defaults to True
+        Raises
+        ------
+        hpcypy.excetions.ShellException :
+            When the underlying shell call fails.
 
         Returns
         -------
-        _type_
-            _description_
+        str
+            Result from the underlying called command.
         """
         result = shell(cmd)
 

--- a/hpcpy/exceptions.py
+++ b/hpcpy/exceptions.py
@@ -1,5 +1,36 @@
+import subprocess as sp
+
+
 class NoClientException(Exception):
     def __init__(self):
         super().__init__(
             "Unable to detect scheduler type, cannot determine client type."
         )
+
+
+class ShellException(Exception):
+    """Exception class to improve readability of the subprocess.CalledProcessError"""
+
+    def __init__(self, called_process_error: sp.CalledProcessError):
+        """Constructor
+
+        Parameters
+        ----------
+        called_process_error : sp.CalledProcessError
+            Source subprocess.CalledError
+        """
+        self.returncode = called_process_error.returncode
+        self.cmd = called_process_error.cmd[0]
+        self.stdout = called_process_error.stdout.decode()
+        self.stderr = called_process_error.stderr.decode()
+        self.output = called_process_error.output
+
+    def __str__(self):
+        """Improved string representation of the error message.
+
+        Returns
+        -------
+        str
+            Improved error messaging
+        """
+        return f"Error {self.returncode}: {self.stderr}"

--- a/hpcpy/utilities.py
+++ b/hpcpy/utilities.py
@@ -5,6 +5,7 @@ import jinja2 as j2
 import jinja2.meta as j2m
 from pathlib import Path
 from importlib import resources
+from hpcpy.exceptions import ShellException
 import shlex
 
 
@@ -27,11 +28,19 @@ def shell(cmd, check=True, capture_output=True, **kwargs) -> sp.CompletedProcess
 
     Raises
     ------
-    subprocess.CalledProcessError
+    hpcypy.excetions.ShellException :
+        When the shell call fails.
     """
-    return sp.run(
-        shlex.split(cmd), check=check, capture_output=capture_output, **kwargs
-    )
+    try:
+        return sp.run(
+            shlex.split(cmd),
+            shell=True,
+            check=check,
+            capture_output=capture_output,
+            **kwargs,
+        )
+    except sp.CalledProcessError as ex:
+        raise ShellException(ex)
 
 
 def interpolate_string_template(template, **kwargs) -> str:

--- a/hpcpy/utilities.py
+++ b/hpcpy/utilities.py
@@ -28,7 +28,7 @@ def shell(cmd, check=True, capture_output=True, **kwargs) -> sp.CompletedProcess
 
     Raises
     ------
-    hpcypy.excetions.ShellException :
+    hpcpy.exceptions.ShellException :
         When the shell call fails.
     """
     try:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,8 +1,17 @@
 """Tests for utilities.py"""
 
 import hpcpy.utilities as hu
+import hpcpy.exceptions as hx
 
 
 def test_interpolate_string_template():
     """Test interpolating a string template."""
     assert hu.interpolate_string_template("hello {{arg}}", arg="world") == "hello world"
+
+
+def test_shell_exception():
+    """Test that error messaging is being raised to the user."""
+    try:
+        hu.shell("blah")
+    except hx.ShellException as ex:
+        assert ex.__str__() == "Error 127: /bin/sh: blah: command not found\n"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -14,4 +14,6 @@ def test_shell_exception():
     try:
         hu.shell("blah")
     except hx.ShellException as ex:
-        assert ex.__str__() == "Error 127: /bin/sh: blah: command not found\n"
+
+        expected = f"Error {ex.returncode}: {ex.stderr}"
+        assert ex.__str__() == expected


### PR DESCRIPTION
As per discussions, a new class with the default behaviour to show more information to the user about the failed underlying shell command.

Added tests and fixed a small omission on the shell call itself.

Error message syntax can be changed, but for now it is:

`Error $CODE: $STDERR\n`

Which is pretty similar to the default, just with more information.

Programmatically, if a user is running into a situation where they are causing exceptions, their code should be made to be robust and handle these exceptions. HPCpy is doing what it should and communicating the error through Exceptions, rather than trying to handle them itself, which is going to be a massive can of worms as different HPC platforms have different setups... (i.e. some may not require a queue or project directive at all, where others do, even if there is only one possible option).