### PR TITLE
depends_on argument now accepts str, Job or a list containing either

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -15,3 +15,4 @@ readthedocs
 io
 generalise
 generalised
+maximise

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -175,7 +175,10 @@ HPCpy implements a simple task-dependence strategy at the scheduler level, where
 === "HPCpy (Python)"
     ```python
     job1 = client.submit("job1.sh")
-    job2 = client.submit("job2.sh", depends_on=job1.id)
+    job2 = client.submit("job2.sh")
+
+    # depends_on accepts a Job ID `str`, `Job()` object, or a list containing either.
+    job3 = client.submit("job3.sh", depends_on=[job1.id, job2])
     ```
 === "PBS"
     ```shell
@@ -184,7 +187,7 @@ HPCpy implements a simple task-dependence strategy at the scheduler level, where
     ```
 
 !!! note
-    The current implementation of the `depends_on` keyword is to take a job id, or a list of job ids.
+    The `depends_on` accepts a Job ID `str`, `Job()` object, or a list containing either to maximise utility.
 
 Consider the following snippet:
 
@@ -192,17 +195,17 @@ Consider the following snippet:
 from hpcpy import get_client
 client = get_client()
 
-# Submit the first job, get the ID
-first_id = client.submit("job.sh").id
+# Submit the first job
+first_job = client.submit("job.sh")
 
 # Submit some interim jobs all requiring the first to finish
-job_ids = list()
+jobs = list()
 for x in range(3):
-    jobx_id = client.submit("job.sh", depends_on=first_id).id
-    job_ids.append(jobx_id)
+    jobx = client.submit("job.sh", depends_on=first_job)
+    job_ids.append(jobx)
 
 # Submit a final job that requires everything to have finished.
-job_last = client.submit("job.sh", depends_on=job_ids)
+job_last = client.submit("job.sh", depends_on=jobs)
 ```
 
 This will create 5 jobs:

--- a/hpcpy/client/base.py
+++ b/hpcpy/client/base.py
@@ -1,6 +1,6 @@
 """Base client object."""
 
-from hpcpy.utilities import shell, interpolate_file_template, get_logger
+from hpcpy.utilities import shell, interpolate_file_template, get_logger, ensure_list
 from hpcpy.job import Job
 import hpcpy.constants as hc
 from random import choice
@@ -413,3 +413,33 @@ class BaseClient:
         """
         directives.append(self.directive_templates[key].format(**kwargs))
         return directives
+
+    def _normalise_depends_on(self, jobs: Union[str, Job, list]) -> list:
+        """Normalise the jobs supplied by a depends_on argument into strings.
+
+        Parameters
+        ----------
+        jobs : Union[str, Job, list]
+            Job ID, Job object or a list containing either.
+
+        Returns
+        -------
+        list
+            List of Job IDs
+
+        Raises
+        ------
+        TypeError
+            When any of the objects is neither a str or a Job object.
+        """
+        normalised = list()
+        for ix, _job in enumerate(ensure_list(jobs)):
+
+            if isinstance(_job, str):
+                normalised.append(_job)
+            elif isinstance(_job, Job):
+                normalised.append(_job.id)
+            else:
+                raise TypeError(f"Object at index {ix} is neither a str or Job object.")
+
+        return normalised

--- a/hpcpy/client/pbs.py
+++ b/hpcpy/client/pbs.py
@@ -2,7 +2,6 @@
 
 from hpcpy.client.base import BaseClient
 from hpcpy.constants.pbs import COMMANDS, DIRECTIVES, STATUSES, DELAY_DIRECTIVE_FMT
-import hpcpy.utilities as hu
 from datetime import datetime, timedelta
 from typing import Union
 import json
@@ -120,10 +119,14 @@ class PBSClient(BaseClient):
 
         # Add job depends
         if depends_on:
+
+            # Normalise to a list of strs
+            depends_on = super()._normalise_depends_on(depends_on)
+
             directives = self._interpolate_directive(
                 directives,
                 "depends_on",
-                depends_on_str=":".join(hu.ensure_list(depends_on)),
+                depends_on_str=":".join(depends_on),
             )
 
         # Add delay (specified time or delta)

--- a/hpcpy/client/slurm.py
+++ b/hpcpy/client/slurm.py
@@ -2,7 +2,6 @@
 
 from hpcpy.client.base import BaseClient
 from hpcpy.constants.slurm import COMMANDS, STATUSES, DIRECTIVES, DELAY_DIRECTIVE_FMT
-import hpcpy.utilities as hu
 from datetime import datetime, timedelta
 from typing import Union
 import json
@@ -124,10 +123,13 @@ class SlurmClient(BaseClient):
 
             self._logger.debug("Job dependency specified.")
 
+            # Normalise depends_on to strs
+            depends_on = super()._normalise_depends_on(depends_on)
+
             directives = self._interpolate_directive(
                 directives,
                 "depends_on",
-                depends_on_str=":".join(hu.ensure_list(depends_on)),
+                depends_on_str=":".join(depends_on),
             )
 
         # Add delay (specified time or delta)

--- a/tests/test_pbs_client.py
+++ b/tests/test_pbs_client.py
@@ -75,6 +75,15 @@ def test_depends_on(client):
     assert result == expected
 
 
+def test_depends_on_normalise(client):
+    """Test if the depends_on argument is correctly applied with a mix of strs and objects."""
+    expected = "qsub -W depend=afterok:job1:job2 test.sh"
+    job2 = Job("job2", auto_update=False, client=client)
+    result = client.submit("test.sh", depends_on=["job1", job2], dry_run=True)
+
+    assert result == expected
+
+
 def test_delay(client):
     """Test if delay is correctly applied"""
     run_at = datetime(2200, 7, 26, 12, 0, 0)

--- a/tests/test_slurm_client.py
+++ b/tests/test_slurm_client.py
@@ -69,6 +69,14 @@ def test_depends_on(client):
     assert expected == result
 
 
+def test_depends_on_normalise(client):
+    """Test that job dependency is correctly applied to the command string."""
+    expected = "sbatch --dependency=afterok:1234:3456 test.sh"
+    job2 = Job("3456", auto_update=False, client=client)
+    result = client.submit("test.sh", depends_on=["1234", job2], dry_run=True)
+    assert expected == result
+
+
 def test_delay(client):
     """Test that delay is correctly applied to the command string."""
     # Set execution to an hour's time


### PR DESCRIPTION
`depends_on` argument now accepts str, Job or a list containing either.

This also introduces backwards compatibility with scripts that used an ID over a job object. Bonus.