### PR TITLE
52 string escaping in variable directives

### DIFF
--- a/hpcpy/client/pbs.py
+++ b/hpcpy/client/pbs.py
@@ -66,7 +66,6 @@ class PBSClient(BaseClient):
         str
             String formatted variables for PBS
         """
-
         formatted = list()
 
         for k, v in variables.items():

--- a/hpcpy/client/pbs.py
+++ b/hpcpy/client/pbs.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Union
 import json
 from pathlib import Path
+from shlex import quote
 
 
 class PBSClient(BaseClient):
@@ -65,7 +66,20 @@ class PBSClient(BaseClient):
         str
             String formatted variables for PBS
         """
-        formatted = ",".join([f"{k}={v}" for k, v in variables.items()])
+
+        formatted = list()
+
+        for k, v in variables.items():
+
+            # Fix for broken quotes #52
+            if isinstance(v, str) and " " in v:
+                v = quote(v)
+                line = f'"{k}={v}"'
+                formatted.append(line)
+            else:
+                formatted.append(f"{k}={v}")
+
+        formatted = ",".join(formatted)
         return f"-v {formatted}"
 
     def submit(

--- a/hpcpy/client/slurm.py
+++ b/hpcpy/client/slurm.py
@@ -53,22 +53,6 @@ class SlurmClient(BaseClient):
         # Return the generic status
         return generic_status, native_full
 
-    def _render_variables(self, variables):
-        """Render the variables flag for PBS.
-
-        Parameters
-        ----------
-        variables : dict
-            Dictionary of variables
-
-        Returns
-        -------
-        str
-            String formatted variables for PBS
-        """
-        formatted = ",".join([f"{k}={v}" for k, v in variables.items()])
-        return f"-v {formatted}"
-
     def submit(
         self,
         job_script: Union[str, Path],

--- a/tests/test_pbs_client.py
+++ b/tests/test_pbs_client.py
@@ -75,15 +75,6 @@ def test_depends_on(client):
     assert result == expected
 
 
-def test_depends_on_normalise(client):
-    """Test if the depends_on argument is correctly applied with a mix of strs and objects."""
-    expected = "qsub -W depend=afterok:job1:job2 test.sh"
-    job2 = Job("job2", auto_update=False, client=client)
-    result = client.submit("test.sh", depends_on=["job1", job2], dry_run=True)
-
-    assert result == expected
-
-
 def test_delay(client):
     """Test if delay is correctly applied"""
     run_at = datetime(2200, 7, 26, 12, 0, 0)
@@ -128,6 +119,15 @@ def test_variables(client):
     result = client.submit(
         "test.sh", dry_run=True, variables=dict(var1=1234, var2="abcd")
     )
+
+    assert result == expected
+
+
+def test_variables_spaces(client):
+    """Test the error reported in https://github.com/ACCESS-NRI/hpcpy/issues/52"""
+    expected = "qsub -v \"msg='HELLO WORLD'\" job.sh"
+
+    result = client.submit("job.sh", dry_run=True, variables=dict(msg="HELLO WORLD"))
 
     assert result == expected
 
@@ -209,3 +209,22 @@ def test_hold_release(fp, client, status_json, job_id):
 
     # Ensure it is queued
     assert job._status == hc.STATUS_QUEUED
+
+
+# def test_remote_host():
+
+#     host = os.getenv("PBS_HOST")
+#     remote_user = os.getenv("PBS_USER")
+#     client = PBSClient(host=host, remote_user=remote_user)
+
+#     assert client._ssh_client != None
+
+# def test_remote_shell():
+#     host = os.getenv("PBS_HOST")
+#     remote_user = os.getenv("PBS_USER")
+#     client = PBSClient(host=host, remote_user=remote_user)
+
+#     result = client._shell("echo $USER")
+#     assert remote_user == result
+
+# def test_

--- a/tests/test_pbs_client.py
+++ b/tests/test_pbs_client.py
@@ -75,6 +75,15 @@ def test_depends_on(client):
     assert result == expected
 
 
+def test_depends_on_normalise(client):
+    """Test if the depends_on argument is correctly applied with a mix of strs and objects."""
+    expected = "qsub -W depend=afterok:job1:job2 test.sh"
+    job2 = Job("job2", auto_update=False, client=client)
+    result = client.submit("test.sh", depends_on=["job1", job2], dry_run=True)
+
+    assert result == expected
+
+
 def test_delay(client):
     """Test if delay is correctly applied"""
     run_at = datetime(2200, 7, 26, 12, 0, 0)
@@ -209,22 +218,3 @@ def test_hold_release(fp, client, status_json, job_id):
 
     # Ensure it is queued
     assert job._status == hc.STATUS_QUEUED
-
-
-# def test_remote_host():
-
-#     host = os.getenv("PBS_HOST")
-#     remote_user = os.getenv("PBS_USER")
-#     client = PBSClient(host=host, remote_user=remote_user)
-
-#     assert client._ssh_client != None
-
-# def test_remote_shell():
-#     host = os.getenv("PBS_HOST")
-#     remote_user = os.getenv("PBS_USER")
-#     client = PBSClient(host=host, remote_user=remote_user)
-
-#     result = client._shell("echo $USER")
-#     assert remote_user == result
-
-# def test_


### PR DESCRIPTION
Fixed the issue around string escaping.

It didn't really seem to be an issue in SLURM as the variables are loaded into the environment via setting the environment argument on a subprocess call, Python looks like it escapes things properly in this instance.

I fixed a couple of missing tests and redundant code in the process.