### PR TITLE
Fix ClientFactory get_client signature

### DIFF
--- a/hpcpy/client/client_factory.py
+++ b/hpcpy/client/client_factory.py
@@ -10,7 +10,7 @@ from typing import Union
 class ClientFactory:
     """An object that agnostically selects a scheduler."""
 
-    def get_client(*args, **kwargs) -> Union[PBSClient, SlurmClient]:
+    def get_client(self, *args, **kwargs) -> Union[PBSClient, SlurmClient]:
         """Get a client object based on what kind of scheduler we are using.
 
         Arguments:


### PR DESCRIPTION
The `ClientFactory` `get_client` method was missing the `self` argument, so the self was being included in the `*args` component.